### PR TITLE
feat: optionally accept subnet_ids

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  subnet_ids = length(var.subnet_ids) > 0 ? var.subnet_ids : data.aws_subnets.subnets.ids
+}

--- a/network.tf
+++ b/network.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "warpstream" {
   name               = var.lb_name
   internal           = false
   load_balancer_type = "network"
-  subnets            = data.aws_subnets.subnets.ids
+  subnets            = local.subnet_ids
 }
 
 resource "aws_lb_listener" "warpstream_agent" {

--- a/service.tf
+++ b/service.tf
@@ -87,7 +87,7 @@ module "service" {
   create_tasks_iam_role = false
   tasks_iam_role_arn    = local.agent_role_arn
 
-  subnet_ids = data.aws_subnets.subnets.ids
+  subnet_ids = local.subnet_ids
   security_group_rules = {
     ingress_http = {
       type        = "ingress"

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "vpc_subnet_visibility_tag" {
   default     = "public"
 }
 
+variable "subnet_ids" {
+  description = "Subnets to use for the ECS service."
+  type        = list(string)
+  default     = []
+}
+
 // agent configuration
 variable "agent_version" {
   description = "Version of the WarpStream Agent."


### PR DESCRIPTION
Allow passing in subnet IDs. If no IDs are provided, default to the current behavior of searching for subnets based on tag.